### PR TITLE
Improve flow

### DIFF
--- a/tools/workspace/mypy_extensions_internal/repository.bzl
+++ b/tools/workspace/mypy_extensions_internal/repository.bzl
@@ -1,5 +1,9 @@
 # -*- python -*-
 
+# This dependency is part of a "cohort" defined in
+# drake/tools/workspace/new_release.py.  This dependency should only be
+# updated in conjunction with the other members of its cohort.
+
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
 def mypy_extensions_internal_repository(

--- a/tools/workspace/mypy_internal/repository.bzl
+++ b/tools/workspace/mypy_internal/repository.bzl
@@ -1,5 +1,9 @@
 # -*- python -*-
 
+# This dependency is part of a "cohort" defined in
+# drake/tools/workspace/new_release.py.  This dependency should only be
+# updated in conjunction with the other members of its cohort.
+
 load("@drake//tools/workspace:github.bzl", "github_archive")
 
 def mypy_internal_repository(

--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -80,6 +80,8 @@ _OVERLOOK_RELEASE_REPOSITORIES = {
 
 # Packages in these cohorts should be upgraded together (in a single commit).
 _COHORTS = (
+    # mypy uses mypy_extensions; be sure to keep them aligned.
+    {"mypy_internal", "mypy_extensions_internal"},
     # sdformat depends on both gz libraries; be sure to keep them aligned.
     {"sdformat_internal", "gz_math_internal", "gz_utils_internal"},
     # uwebsockets depends on usockets; be sure to keep them aligned.

--- a/tools/workspace/new_release.py
+++ b/tools/workspace/new_release.py
@@ -36,19 +36,20 @@ command line.
 import argparse
 import getpass
 import git
-import glob
+import github3
 import hashlib
 import json
 import logging
 import os
 import re
+import shlex
 import subprocess
-import sys
-from tempfile import TemporaryDirectory
 import time
 import urllib
 
-import github3
+from dataclasses import dataclass
+from tempfile import TemporaryDirectory
+from typing import List, Optional
 
 from drake.tools.workspace.metadata import read_repository_metadata
 
@@ -79,13 +80,19 @@ _OVERLOOK_RELEASE_REPOSITORIES = {
 
 # Packages in these cohorts should be upgraded together (in a single commit).
 _COHORTS = (
-    # The uwebsockets depends on usockets;
-    # be sure to keep them in alignment.
-    ("uwebsockets", "usockets"),
-    # The sdformat depends on both gz libraries;
-    # be sure to keep them in alignment.
-    ("sdformat_internal", "gz_math_internal", "gz_utils_internal"),
+    # sdformat depends on both gz libraries; be sure to keep them aligned.
+    {"sdformat_internal", "gz_math_internal", "gz_utils_internal"},
+    # uwebsockets depends on usockets; be sure to keep them aligned.
+    {"uwebsockets", "usockets"},
 )
+
+
+@dataclass
+class UpgradeResult:
+    was_upgraded: bool
+    can_be_committed: bool = False
+    modified_paths: Optional[List[str]] = None
+    commit_message: Optional[str] = None
 
 
 def _check_output(args):
@@ -229,119 +236,153 @@ def _is_modified(repo, path):
     return False
 
 
-def _do_upgrade(temp_dir, gh, local_drake_checkout,
-                workspace_names, metadata, commit_changes):
-
-    # Make sure there are workspaces to update.
-    if len(workspace_names) == 0:
-        return
-
-    for workspace_name in workspace_names:
-        if workspace_name not in metadata:
-            raise RuntimeError(f"Unknown repository {workspace_name}")
-        if metadata[workspace_name]["repository_rule_type"] != "github":
-            raise RuntimeError(f"Cannot auto-upgrade {workspace_name}")
-
-    messages = []
-    bzl_filenames = []
-    for workspace_name in workspace_names:
-        data = metadata[workspace_name]
-        repository = data["repository"]
-
-        # Slurp the file we're supposed to modify.
-        bzl_filename = f"tools/workspace/{workspace_name}/repository.bzl"
-        with open(bzl_filename, "r", encoding="utf-8") as f:
-            lines = f.readlines()
-
-        # Figure out what to upgrade.
-        old_commit, new_commit = _handle_github(workspace_name, gh, data)
-        if old_commit == new_commit:
-            raise RuntimeError(f"No upgrade needed for {workspace_name}")
-        elif new_commit is None:
-            raise RuntimeError(f"Cannot auto-upgrade {workspace_name}")
-        print("Upgrading {} from {} to {}".format(
-            workspace_name, old_commit, new_commit))
-
-        # Locate the two hexadecimal lines we need to edit.
-        commit_line_re = re.compile(
-            r'(?<=    commit = ")(' + re.escape(old_commit) + r')(?=",)')
-        checksum_line_re = re.compile(
-            r'(?<=    sha256 = ")([0-9a-f]{64})(?=",)')
-        commit_line_num = None
-        checksum_line_num = None
-        for i, line in enumerate(lines):
-            match = commit_line_re.search(line)
-            if match:
-                assert commit_line_num is None
-                commit_line_num = i
-                commit_line_match = match
-            match = checksum_line_re.search(line)
-            if match:
-                assert checksum_line_num is None
-                checksum_line_num = i
-                checksum_line_match = match
-        assert commit_line_num is not None
-        assert checksum_line_num is not None
-
-        # Download the new source archive.
-        print("Downloading new archive...")
-        new_url = f"https://github.com/{repository}/archive/{new_commit}.tar.gz"  # noqa: E501
-        hasher = hashlib.sha256()
-        with open(f"{temp_dir}/{new_commit}.tar.gz", "wb") as temp:
-            with urllib.request.urlopen(new_url) as response:
-                while True:
-                    data = response.read(4096)
-                    if not data:
-                        break
-                    hasher.update(data)
-                    temp.write(data)
-                new_checksum = hasher.hexdigest()
-
-        # Update the repository.bzl contents and then write it out.
-        lines[commit_line_num] = commit_line_re.sub(
-            new_commit, lines[commit_line_num])
-        lines[checksum_line_num] = checksum_line_re.sub(
-            new_checksum, lines[checksum_line_num])
-        with open(bzl_filename + ".new", "w", encoding="utf-8") as f:
-            for line in lines:
-                f.write(line)
-        os.rename(bzl_filename + ".new", bzl_filename)
-        bzl_filenames.append(bzl_filename)
-
-        # Copy the downloaded tarball into the repository cache.
-        print("Populating repository cache ...")
-        subprocess.check_call(["bazel", "fetch",
-                               "//...", f"--distdir={temp_dir}"])
-
-        message = f"[workspace] Upgrade {workspace_name}"
-        if _smells_like_a_git_commit(new_commit):
-            message += " to latest commit"
-        else:
-            message += f" to latest release {new_commit}"
-        messages.append(message)
-
-    if commit_changes:
-        msg_string = "\n".join(messages)
-        local_drake_checkout.git.commit('-o', bzl_filenames, '-m', msg_string)
+def _do_commit(local_drake_checkout, actually_commit,
+               workspace_names, paths, message):
+    if actually_commit:
+        names = ", ".join(workspace_names)
+        path_args = zip(['-o'] * len(paths), paths)
+        local_drake_checkout.git.commit(
+            *path_args, '-m', "[workspace] " + message)
         print("\n" + ("*" * 72))
-        workspace_names = list(workspace_names)
-        if len(workspace_names) == 1:
-            wn_string = workspace_names[0]
-        elif len(workspace_names) == 2:
-            wn_string = workspace_names[0] + " and " + workspace_names[1]
-        else:
-            wn_string = ", ".join(workspace_names[:-1])\
-                        + "and " + workspace_names[-1]
-        print(f"Done.  Changes for {wn_string} were committed.")
+        print(f"Done.  Changes for {names} were committed.")
         print("Be sure to review the changes and amend the commit if needed.")
         print(("*" * 72) + "\n")
     else:
         print("\n" + ("*" * 72))
         print("Done.  Be sure to review and commit the changes:")
-        print(f"  git add {' '.join(bzl_filenames)}")
-        msg_string = '\\\n'.join(messages)
-        print(f"  git commit -m '{msg_string}'")
+        print(f"  git add {' '.join([shlex.quote(p) for p in paths])}")
+        print(f"  git commit -m{shlex.quote(message)}")
         print(("*" * 72) + "\n")
+
+
+def _do_upgrade(temp_dir, gh, local_drake_checkout, workspace_name, metadata):
+    """Returns an `UpgradeResult` describing what (if anything) was done."""
+    if workspace_name not in metadata:
+        raise RuntimeError(f"Unknown repository {workspace_name}")
+    data = metadata[workspace_name]
+    if data["repository_rule_type"] != "github":
+        raise RuntimeError(f"Cannot auto-upgrade {workspace_name}")
+    repository = data["repository"]
+
+    # Slurp the file we're supposed to modify.
+    bzl_filename = f"tools/workspace/{workspace_name}/repository.bzl"
+    with open(bzl_filename, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    # Determine if we should and can commit the changes made.
+    if local_drake_checkout is not None:
+        if _is_modified(local_drake_checkout, bzl_filename):
+            print(f"{bzl_filename} has local changes.")
+            print(f"Changes made for {workspace_name} will NOT be committed.")
+            can_commit = False
+        else:
+            can_commit = True
+    else:
+        can_commit = False
+
+    # Figure out what to upgrade.
+    old_commit, new_commit = _handle_github(workspace_name, gh, data)
+    if old_commit == new_commit:
+        return UpgradeResult(False)
+    elif new_commit is None:
+        raise RuntimeError(f"Cannot auto-upgrade {workspace_name}")
+    print("Upgrading {} from {} to {}".format(
+        workspace_name, old_commit, new_commit))
+
+    # Locate the two hexadecimal lines we need to edit.
+    commit_line_re = re.compile(
+        r'(?<=    commit = ")(' + re.escape(old_commit) + r')(?=",)')
+    checksum_line_re = re.compile(
+        r'(?<=    sha256 = ")([0-9a-f]{64})(?=",)')
+    commit_line_num = None
+    checksum_line_num = None
+    for i, line in enumerate(lines):
+        match = commit_line_re.search(line)
+        if match:
+            assert commit_line_num is None
+            commit_line_num = i
+        match = checksum_line_re.search(line)
+        if match:
+            assert checksum_line_num is None
+            checksum_line_num = i
+    assert commit_line_num is not None
+    assert checksum_line_num is not None
+
+    # Download the new source archive.
+    print("Downloading new archive...")
+    new_url = f"https://github.com/{repository}/archive/{new_commit}.tar.gz"
+    hasher = hashlib.sha256()
+    with open(f"{temp_dir}/{new_commit}.tar.gz", "wb") as temp:
+        with urllib.request.urlopen(new_url) as response:
+            while True:
+                data = response.read(4096)
+                if not data:
+                    break
+                hasher.update(data)
+                temp.write(data)
+            new_checksum = hasher.hexdigest()
+
+    # Update the repository.bzl contents and then write it out.
+    lines[commit_line_num] = commit_line_re.sub(
+        new_commit, lines[commit_line_num])
+    lines[checksum_line_num] = checksum_line_re.sub(
+        new_checksum, lines[checksum_line_num])
+    with open(bzl_filename + ".new", "w", encoding="utf-8") as f:
+        for line in lines:
+            f.write(line)
+    os.rename(bzl_filename + ".new", bzl_filename)
+
+    # Copy the downloaded tarball into the repository cache.
+    print("Populating repository cache ...")
+    subprocess.check_call(["bazel", "fetch", "//...", f"--distdir={temp_dir}"])
+
+    message = f"Upgrade {workspace_name} to latest"
+    if _smells_like_a_git_commit(new_commit):
+        message += " commit"
+    else:
+        message += f" release {new_commit}"
+
+    return UpgradeResult(True, can_commit, [bzl_filename], message)
+
+
+def _do_upgrades(temp_dir, gh, local_drake_checkout,
+                 workspace_names, metadata):
+
+    # Make sure there are workspaces to update.
+    if len(workspace_names) == 0:
+        return
+
+    can_commit = True
+    modified_paths = []
+    commit_messages = []
+    modified_workspace_names = []
+    for workspace_name in workspace_names:
+        result = _do_upgrade(temp_dir, gh, local_drake_checkout,
+                             workspace_name, metadata)
+        if result.was_upgraded:
+            can_commit = can_commit and result.can_be_committed
+            modified_paths += result.modified_paths
+            commit_messages.append(result.commit_message)
+            modified_workspace_names.append(workspace_name)
+        elif len(workspace_names) == 1:
+            raise RuntimeError(f"No upgrade needed for {workspace_name}")
+
+    # Determine if we should and can commit the changes made.
+    if len(modified_workspace_names) == 1:
+        _do_commit(local_drake_checkout, actually_commit=can_commit,
+                   workspace_names=modified_workspace_names,
+                   paths=modified_paths, message=commit_messages[0])
+    else:
+        cohort = ', '.join(modified_workspace_names)
+
+        if not can_commit:
+            print(f"Changes made for {cohort} will NOT be committed.")
+
+        message = f"Upgrade {cohort} to latest\n\n"
+        message += "- " + "\n- ".join(commit_messages)
+        _do_commit(local_drake_checkout, actually_commit=can_commit,
+                   workspace_names=modified_workspace_names,
+                   paths=modified_paths, message=message)
 
 
 def main():
@@ -396,7 +437,14 @@ def main():
 
     # Are we operating on all repositories, or just one?
     if len(args.workspace):
-        workspaces = args.workspace
+        workspaces = set(args.workspace)
+
+        # Grow the set of specified repositories to cover cohorts.
+        for workspace in args.workspace:
+            for cohort in _COHORTS:
+                if workspace in cohort:
+                    workspaces.update(cohort)
+
     else:
         if args.commit:
             parser.error("--commit requires one or more workspaces.")
@@ -415,54 +463,23 @@ def main():
         print(json.dumps(metadata, sort_keys=True, indent=2))
 
     if workspaces is not None:
-        # Generate a set of workspaces which are members of a cohort and
-        # need to be updated.
-        available_updates = set()
-        for cohort in _COHORTS:
-            for workspace in cohort:
-                data = read_repository_metadata(repositories=[workspace])
-                old_commit, new_commit = \
-                    _handle_github(workspace, gh, data[workspace])
-                if old_commit != new_commit and new_commit is not None:
-                    available_updates.add(workspace)
-
+        visited_workspaces = set()
         for workspace in workspaces:
-            for cohort in _COHORTS:
-                if workspace in cohort:
-                    # Make sure all members of a cohort are being updated
-                    # together if possible.
-                    for cohort_item in cohort:
-                        if cohort_item not in workspaces \
-                           and cohort_item in available_updates:
-                            parser.error(f"Members of cohort {cohort} must be"
-                                         " upgraded together if possible")
-
-        workspaces_to_commit = set()
-        workspaces_dont_commit = set()
-        for workspace in workspaces:
-            # Don't try to update things which have no available updates
-            if workspace not in available_updates:
-                raise RuntimeError(f"No upgrade needed for {workspace}")
+            # If we already did this as part of a tandem upgrade, skip it.
+            if workspace in visited_workspaces:
                 continue
 
-            # Determine if we should and can commit the changes made.
-            if local_drake_checkout is not None:
-                bzl_filename = f"tools/workspace/{workspace}/repository.bzl"
-                if _is_modified(local_drake_checkout, bzl_filename):
-                    print(f"{bzl_filename} has local changes.")
-                    print(f"Changes made for {workspace}"
-                          " will NOT be committed.")
-                    workspaces_dont_commit.add(workspace)
-                else:
-                    workspaces_to_commit.add(workspace)
-            else:
-                workspaces_dont_commit.add(workspace)
+            # Determine if this workspace is part of a cohort.
+            cohort_workspaces = {workspace}
+            for cohort in _COHORTS:
+                if workspace in cohort:
+                    cohort_workspaces = cohort
 
-        with TemporaryDirectory(prefix='drake_new_release_') as temp_dir:
-            _do_upgrade(temp_dir, gh, local_drake_checkout,
-                        workspaces_to_commit, metadata, commit_changes=True)
-            _do_upgrade(temp_dir, gh, local_drake_checkout,
-                        workspaces_dont_commit, metadata, commit_changes=False)
+            # Actually do the upgrade(s).
+            with TemporaryDirectory(prefix='drake_new_release_') as temp_dir:
+                _do_upgrades(temp_dir, gh, local_drake_checkout,
+                             cohort_workspaces, metadata)
+                visited_workspaces.update(cohort_workspaces)
     else:
         # Run our report of what's available.
         print("Checking for new releases...")


### PR DESCRIPTION
@williamjallen, implements suggestions from https://github.com/RobotLocomotion/drake/pull/18673 and also splits `_do_upgrade` into two functions; one to handle consolidating things, and one to handle a single workspace, which makes it almost identical to the old version. (It's sort of a mess now, but will make the final PR easier to review. If you can, you might want to compare this vs. master.)

Since that PR is going to get squashed anyway, neither the commit message here nor the manner in which it gets slurped back into your branch (e.g. merge, squash, rebase) matter.

Tested on `tinyobjloader` and `usockets`; the latter both "as is" (which as of writing, causes `uwebsockets` to be updated and *no* change to `usockets`) and with the previous update locally reverted so that both of `u[web]sockets` are updated.